### PR TITLE
Handle special paths in marvim_store

### DIFF
--- a/plugin/marvim.vim
+++ b/plugin/marvim.vim
@@ -48,6 +48,9 @@ if exists('g:marvim_store')
     else
         let g:marvim_store = g:marvim_store
     endif
+    " Expend the variable according to the path in the computer (to handle ~ for
+    " example).
+    let g:marvim_store = expand(g:marvim_store)
 else
     let g:marvim_store = s:marvim_store
 endif


### PR DESCRIPTION
In the case that there are special character in the marvim_store
variable, they weren't expended, and the paths turn out to be different
than the wanted paths.

To fix this bug, a call to expand was added, so the path will be
expanded to the wanted path before using it.

Now, the plugin handle the case of having ~ for example in the value of
g:marvim_store, and it will get the wanted path in the home directory.

Partially fixes #13